### PR TITLE
Potential fix for code scanning alert no. 25: Uncontrolled data used in path expression

### DIFF
--- a/tests/rkls_github_canned_server.py
+++ b/tests/rkls_github_canned_server.py
@@ -27,7 +27,11 @@ def create_app(test_config=None):
                 "tree": []
             }
         # FIXME: Pull contents from directory
-        for file in os.listdir(f'tests/data/recklessrepo/{github_user}/{plugin_name}'):
+        base_path = 'tests/data/recklessrepo'
+        user_path = os.path.normpath(os.path.join(base_path, github_user, plugin_name))
+        if not user_path.startswith(base_path):
+            raise Exception("Invalid path")
+        for file in os.listdir(user_path):
             dir_json["tree"].append({"path": file})
         resp = flask.Response(response=json.dumps(dir_json),
                               headers={'Content-Type': 'application/json; charset=utf-8'})


### PR DESCRIPTION
Potential fix for [https://github.com/Yardapemines/lightning/security/code-scanning/25](https://github.com/Yardapemines/lightning/security/code-scanning/25)

To fix the problem, we need to ensure that the constructed file path is safe and does not allow directory traversal. We can achieve this by normalizing the path and ensuring it is contained within a predefined safe directory. We will use `os.path.normpath` to normalize the path and then check if the resulting path starts with the safe base directory.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
